### PR TITLE
Import `resetLDMocks` in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ methods of this object are jest mocks.
 
 ## Example
 ```tsx
-import { mockFlags, ldClientMock } from 'jest-launchdarkly-mock'
+import { mockFlags, ldClientMock, resetLDMocks } from 'jest-launchdarkly-mock'
 
 describe('button', () => {
   beforeEach(() => {


### PR DESCRIPTION
Noticed that `resetLDMocks` is used without being imported from the library.