### PR TITLE
[issue-#6] Include flag as is (no case formatting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Use the only 3 apis for test cases:
 ###### Options
 | name | type | default | description |
 | ---- | ---- | ------- | ----------- |
-| skipFormatting(optional) | boolean | false | If true, flags will not be formatting to camelCase or kebab-case |
+| skipFormatting(optional) | boolean | false | If true, flags will not be formatted to camelCase or kebab-case |
 
 * `ldClientMock`: a jest mock of the [ldClient](https://launchdarkly.github.io/js-client-sdk/interfaces/_launchdarkly_js_client_sdk_.ldclient.html). All
 methods of this object are jest mocks.

--- a/README.md
+++ b/README.md
@@ -32,11 +32,7 @@ module.exports = {
 ## Usage
 Use the only 3 apis for test cases:
 
-* `mockFlags(flags: LDFlagSet, Options?: mockFlagsOptions)`: mock flags at the start of each test case. 
-###### Options
-| name | type | default | description |
-| ---- | ---- | ------- | ----------- |
-| skipFormatting(optional) | boolean | false | If true, flags will not be formatted to camelCase or kebab-case |
+`mockFlags(flags: LDFlagSet)`: mock flags at the start of each test case.
 
 * `ldClientMock`: a jest mock of the [ldClient](https://launchdarkly.github.io/js-client-sdk/interfaces/_launchdarkly_js_client_sdk_.ldclient.html). All
 methods of this object are jest mocks.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ module.exports = {
 ## Usage
 Use the only 3 apis for test cases:
 
-* `mockFlags(flags: LDFlagSet)`: mock flags at the start of each test case.
+* `mockFlags(flags: LDFlagSet, Options?: mockFlagsOptions)`: mock flags at the start of each test case. 
+###### Options
+| name | type | default | description |
+| ---- | ---- | ------- | ----------- |
+| skipFormatting(optional) | boolean | false | If true, flags will not be formatting to camelCase or kebab-case |
 
 * `ldClientMock`: a jest mock of the [ldClient](https://launchdarkly.github.io/js-client-sdk/interfaces/_launchdarkly_js_client_sdk_.ldclient.html). All
 methods of this object are jest mocks.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -25,8 +25,8 @@ describe('main', () => {
     expect(current['dev-test-flag']).toBeTruthy()
   })
 
-  test('mock "skipFormatting: true" option correctly', () => {
-    mockFlags({ DEV_test_Flag: true }, { skipFormatting: true })
+  test('mock option without case formatting correctly', () => {
+    mockFlags({ DEV_test_Flag: true })
 
     const {
       result: { current },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -25,6 +25,17 @@ describe('main', () => {
     expect(current['dev-test-flag']).toBeTruthy()
   })
 
+  test('mock "skipFormatting: true" option correctly', () => {
+    mockFlags({ DEV_test_Flag: true }, { skipFormatting: true })
+
+    const {
+      result: { current },
+    } = renderHook(() => useFlags())
+
+    expect(current.DEV_test_Flag).toBeTruthy()
+    expect(current['DEV_test_Flag']).toBeTruthy()
+  })
+
   test('mock ldClient correctly', () => {
     const {
       result: { current },

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,10 @@ import camelCase from 'lodash.camelcase'
 import { LDFlagSet } from 'launchdarkly-js-sdk-common'
 import { useFlags, useLDClient, withLDConsumer } from 'launchdarkly-react-client-sdk'
 
+type mockFlagsOptions = {
+  skipFormatting?: boolean
+}
+
 const mockUseFlags = useFlags as jest.Mock
 const mockUseLDClient = useLDClient as jest.Mock
 const mockWithLDConsumer = withLDConsumer as jest.Mock
@@ -37,15 +41,21 @@ export const ldClientMock = {
 mockUseLDClient.mockImplementation(() => ldClientMock)
 mockWithLDConsumer.mockImplementation(() => () => null)
 
-export const mockFlags = (flags: LDFlagSet) => {
+export const mockFlags = (flags: LDFlagSet, options?: mockFlagsOptions) => {
   mockUseFlags.mockImplementation(() => {
     const result: LDFlagSet = {}
-    Object.keys(flags).forEach((k) => {
-      const kebab = kebabCase(k)
-      const camel = camelCase(k)
-      result[kebab] = flags[k]
-      result[camel] = flags[k]
-    })
+    if (options?.skipFormatting) {
+      Object.keys(flags).forEach((k) => {
+        result[k] = flags[k]
+      })
+    } else {
+      Object.keys(flags).forEach((k) => {
+        const kebab = kebabCase(k)
+        const camel = camelCase(k)
+        result[kebab] = flags[k]
+        result[camel] = flags[k]
+      })
+    }
     return result
   })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,6 @@ import camelCase from 'lodash.camelcase'
 import { LDFlagSet } from 'launchdarkly-js-sdk-common'
 import { useFlags, useLDClient, withLDConsumer } from 'launchdarkly-react-client-sdk'
 
-type mockFlagsOptions = {
-  skipFormatting?: boolean
-}
-
 const mockUseFlags = useFlags as jest.Mock
 const mockUseLDClient = useLDClient as jest.Mock
 const mockWithLDConsumer = withLDConsumer as jest.Mock
@@ -41,21 +37,16 @@ export const ldClientMock = {
 mockUseLDClient.mockImplementation(() => ldClientMock)
 mockWithLDConsumer.mockImplementation(() => () => null)
 
-export const mockFlags = (flags: LDFlagSet, options?: mockFlagsOptions) => {
+export const mockFlags = (flags: LDFlagSet) => {
   mockUseFlags.mockImplementation(() => {
     const result: LDFlagSet = {}
-    if (options?.skipFormatting) {
-      Object.keys(flags).forEach((k) => {
-        result[k] = flags[k]
-      })
-    } else {
-      Object.keys(flags).forEach((k) => {
-        const kebab = kebabCase(k)
-        const camel = camelCase(k)
-        result[kebab] = flags[k]
-        result[camel] = flags[k]
-      })
-    }
+    Object.keys(flags).forEach((k) => {
+      const kebab = kebabCase(k)
+      const camel = camelCase(k)
+      result[kebab] = flags[k]
+      result[camel] = flags[k]
+      result[k] = flags[k]
+    })
     return result
   })
 }


### PR DESCRIPTION
Added optional second parameter to `mockFlags()` function that is of type:
```
type mockFlagsOptions = {
  skipFormatting?: boolean
}
```
If skipFormatting is true, the flags will be mocked without formatting them to camelCase and kebab-case.

Related to https://github.com/launchdarkly-labs/jest-launchdarkly-mock/issues/6

### EDIT #1:
*Based on code review comment, the original flag is added as-is so the pristine value is returned*