### PR TITLE
feat(withLDProvider): adding mock support for withLDProvider

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,17 +5,19 @@ jest.mock('launchdarkly-react-client-sdk', () => {
     useLDClient: jest.fn(),
     useFlags: jest.fn(),
     withLDConsumer: jest.fn(),
+    withLDProvider: jest.fn(),
   }
 })
 
 import kebabCase from 'lodash.kebabcase'
 import camelCase from 'lodash.camelcase'
 import { LDFlagSet } from 'launchdarkly-js-sdk-common'
-import { useFlags, useLDClient, withLDConsumer } from 'launchdarkly-react-client-sdk'
+import { useFlags, useLDClient, withLDConsumer, withLDProvider } from 'launchdarkly-react-client-sdk'
 
 const mockUseFlags = useFlags as jest.Mock
 const mockUseLDClient = useLDClient as jest.Mock
 const mockWithLDConsumer = withLDConsumer as jest.Mock
+const mockWithLDProvider = withLDProvider as jest.Mock
 
 export const ldClientMock = {
   track: jest.fn(),
@@ -36,6 +38,7 @@ export const ldClientMock = {
 
 mockUseLDClient.mockImplementation(() => ldClientMock)
 mockWithLDConsumer.mockImplementation(() => () => null)
+mockWithLDProvider.mockImplementation(() => (children: any) => children)
 
 export const mockFlags = (flags: LDFlagSet) => {
   mockUseFlags.mockImplementation(() => {


### PR DESCRIPTION
This package currently doesn't mock `withLDProvider`. This PR adds support for mocking the same.